### PR TITLE
Fix ethd version

### DIFF
--- a/ethd
+++ b/ethd
@@ -20,17 +20,17 @@ version() {
   case "${__value}" in
     *bor.yml* )
       echo "Heimdall"
-      docompose exec heimdalld heimdalld version
+      __docompose exec heimdalld heimdalld version
       echo
       echo "Bor"
-      docompose exec bor bor version
+      __docompose exec bor bor version
       echo
       ;;&
     *grafana.yml* )
-      docompose exec prometheus /bin/prometheus --version
+      __docompose exec prometheus /bin/prometheus --version
       echo
       echo -n "Grafana "
-      docompose exec grafana /run.sh -v
+      __docompose exec grafana /run.sh -v
       echo
       ;;&
   esac


### PR DESCRIPTION
copy/paste error: `docompose` is now `__docompose`