### PR TITLE
Heimdall snapshot warning fix

### DIFF
--- a/polygon/docker-entrypoint-heimdalld.sh
+++ b/polygon/docker-entrypoint-heimdalld.sh
@@ -112,7 +112,7 @@ if [ ! -f /var/lib/heimdall/setupdone ]; then
       elif [[ "${filename}" =~ \.tar$ ]]; then
         tar xvf "${filename}" -C /var/lib/heimdall/data/
       elif [[ "${filename}" =~ \.lz4$ ]]; then
-        lz4 -d "${filename}" | tar xvf - -C /var/lib/heimdall/data/
+        lz4 -c -d "${filename}" | tar xvf - -C /var/lib/heimdall/data/
       else
         __dont_rm=1
         echo "The snapshot file has a format that Polygon Docker can't handle."


### PR DESCRIPTION
`lz4 -c` to quiet warning when unpacking heimdall snapshot