### PR TITLE
Fix initial heimdall-v2 migration and setup

### DIFF
--- a/polygon/Dockerfile.heimdall
+++ b/polygon/Dockerfile.heimdall
@@ -28,4 +28,4 @@ COPY ./docker-entrypoint-heimdalld.sh /usr/local/bin/docker-entrypoint.sh
 
 USER ${USER}
 
-CMD [ "/bin/sh", "-c", "# (nop)" ]
+CMD [ "heimdalld" ]


### PR DESCRIPTION
`init` alone doesn't do it. Fetch the genesis file, copy addrbook.json, create a fresh config after moving the original config dir, and adjust toml variables in their new location