### PR TITLE
Bor WS and self-heal heimdall, for v2

### DIFF
--- a/bor.yml
+++ b/bor.yml
@@ -72,6 +72,8 @@ services:
       - EXTRAS=${BOR_EXTRAS:-}
       - SNAPSHOT=${BOR_SNAPSHOT}
       - SNAPSHOT_PART=${BOR_SNAPSHOT_PART}
+      - HEIMDALL_REPO=${HEIMDALL_REPO}
+      - HEIMDALL_RPC_PORT=${HEIMDALL_RPC_PORT:-26657}
     networks:
       default:
         aliases:

--- a/polygon/docker-entrypoint.sh
+++ b/polygon/docker-entrypoint.sh
@@ -190,8 +190,13 @@ else
   else
     __pbss=""
   fi
+  if [[ "${HEIMDALL_REPO}" = *"heimdall-v2" ]]; then
+    __ws="--bor.heimdallWS ${NETWORK}-heimdalld:${HEIMDALL_RPC_PORT}/websocket"
+  else
+    __ws=""
+  fi
 # shellcheck disable=SC2086
-  bor dumpconfig "$@" ${__pbss} ${__verbosity} ${__bootnodes} ${EXTRAS} >/var/lib/bor/config.toml
+  bor dumpconfig "$@" ${__ws} ${__pbss} ${__verbosity} ${__bootnodes} ${EXTRAS} >/var/lib/bor/config.toml
   # Set user-supplied trusted nodes, also as static
   if [ -n "${TRUSTED_NODES}" ]; then
     for string in $(jq -r .[] <<< "${TRUSTED_NODES}"); do


### PR DESCRIPTION
Simpler `init` now that `config` is moved out first

Set Bor WebSocket to Heimdall with v2

Enable self-healing for Heimdall: Note this will need to be revisited for mainnet, to make sure it's functional and recommended. Otherwise, gate behind `amoy` network.
