### PR TITLE
Fix Bor v2.7.0 dumpconfig regression for chain and datadir

### DIFF
--- a/polygon/docker-entrypoint.sh
+++ b/polygon/docker-entrypoint.sh
@@ -212,5 +212,5 @@ else
 # shellcheck disable=SC2116
       dasel put -v "${BOR_ADDRESSCACHESIZES}" -f /var/lib/bor/config.toml '.cache.addresscachesizes'
   fi
-  exec bor server --config /var/lib/bor/config.toml
+  exec bor server --config /var/lib/bor/config.toml "$@"
 fi


### PR DESCRIPTION
## Summary

* Bor v2.7.0 `dumpconfig` no longer writes `--chain` and `--datadir` values to the generated config.toml
* This causes "chain not found" crash loops and the node creating a new empty database at the wrong path
* Patch both values with `dasel` after `dumpconfig` runs in the entrypoint